### PR TITLE
Add link to llvm downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ You need to be running the latest version of [llvm/clang](https://llvm.org/) for
 
 On macOS with [homebrew](https://brew.sh/) installed, run `brew install llvm`
 
+You can also download pre-built binaries from [here](http://releases.llvm.org/download.html) for most operating systems.
+
 Once you have `clang` in play, this is how to compile `fib.c` to `fib.wasm`:
 
 ```


### PR DESCRIPTION
I'm not sure if this is interesting, but it's also possible to download clang/llvm pre-built binaries from [here](http://releases.llvm.org/download.html). I'm stuck on Mac OS X 10.11 and it made things easier.